### PR TITLE
Implemented Meson as a Build System for OpenFSAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ With the traveling salesman problem setup and simulated annealing initialization
 Which can then view the optimal state array in the form of `ts_simanneal%state_best` with an energy (path length) of `ts_simanneal%e_best`.
 
 ---
+## Installation
+___
+
+OpenFSAM can optionally be installed as a shared library using the [Meson Build System](https://www.mesonbuild.com) in the event that you wish to link your program to it.
+
+After [installing Meson](https://mesonbuild.com/SimpleStart.html), installing OpenFSAM is as simple as running `meson setup build` followed by `meson -C build install`.
+
+---
 ## Simulated Annealing for Continuous Function Optimization
 ---
 

--- a/examples/continuous_test/meson.build
+++ b/examples/continuous_test/meson.build
@@ -1,0 +1,5 @@
+continuous_exec = executable(
+  'continuous_test',
+  'main.f90',
+  dependencies: openfsam_dep,
+)

--- a/examples/ising/meson.build
+++ b/examples/ising/meson.build
@@ -1,0 +1,5 @@
+ising_exec = executable(
+  'ising',
+  'ising.f90',
+  dependencies: openfsam_dep,
+)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,4 @@
+subdir('continuous_test')
+subdir('ising')
+subdir('sa_ts_sa')
+subdir('traveling_sales_general')

--- a/examples/sa_ts_sa/meson.build
+++ b/examples/sa_ts_sa/meson.build
@@ -1,0 +1,14 @@
+sa_ts_sa_srcs = files(
+  'globals.f90',
+  'infuncs.f90',
+  'outfuncs.f90',
+  'sa_ts_sa.f90',
+  'travel_sales.f90',
+)
+
+sa_ts_sa_exec = executable(
+  'sa_ts_sa',
+  'main.f90',
+  sources: sa_ts_sa_srcs,
+  dependencies: openfsam_dep,
+)

--- a/examples/traveling_sales_general/meson.build
+++ b/examples/traveling_sales_general/meson.build
@@ -1,0 +1,13 @@
+traveling_sales_general_srcs = files(
+  'globals.f90',
+  'infuncs.f90',
+  'outfuncs.f90',
+  'travel_sales.f90',
+)
+
+traveling_sales_general_exec = executable(
+  'traveling_sales_general',
+  'main.f90',
+  sources: traveling_sales_general_srcs,
+  dependencies: openfsam_dep,
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,38 @@
+project(
+  'OpenFSAM',
+  'fortran',
+  license: 'MIT',
+  license_files: 'LICENSE',
+  default_options: [
+    'buildtype=debugoptimized',
+    'default_library=both',
+  ],
+)
+install = not (meson.is_subproject() and get_option('default_library') == 'static')
+
+# Grab OpenFSAM Sources
+srcs = []
+subdir('src')
+
+# Build/Install OpenFSAM
+openfsam_lib = library(
+  meson.project_name(),
+  sources: srcs,
+  install: install,
+)
+
+pkg = import('pkgconfig')
+pkg.generate(
+  openfsam_lib,
+  description: 'An open source Fortran based simulated annealing utility',
+)
+
+# Export OpenFSAM as a Dependency for Other Projects (and Examples)
+openfsam_inc = openfsam_lib.private_dir_include()
+openfsam_dep = declare_dependency(
+  link_with: openfsam_lib,
+  include_directories: openfsam_inc,
+)
+
+# Build the Examples
+subdir('examples')

--- a/src/OpenFSAM.f90
+++ b/src/OpenFSAM.f90
@@ -159,7 +159,7 @@ CONTAINS
 
     !allocate the neighbor state variables and set the cooling, also set initial energy
     SELECTTYPE(thisSA)
-      TYPEIS(sa_comb_type)
+      TYPE IS(sa_comb_type)
         thisSA%size_states=SIZE(thisSA%state_curr)
         IF(.NOT. ALLOCATED(thisSA%state_neigh))THEN
           ALLOCATE(thisSA%state_neigh(thisSA%size_states))
@@ -172,7 +172,7 @@ CONTAINS
         !set energy to current energy
         e_curr=thisSA%energy(thisSA%state_curr)
         thisSA%e_best=e_curr
-      TYPEIS(sa_cont_type)
+      TYPE IS(sa_cont_type)
         thisSA%size_states=SIZE(thisSA%state_curr)
         IF(.NOT. ALLOCATED(thisSA%state_neigh))THEN
           ALLOCATE(thisSA%state_neigh(thisSA%size_states))
@@ -191,7 +191,7 @@ CONTAINS
           thisSA%smin=MINVAL(thisSA%state_curr)
         ENDIF
         IF(thisSA%damping .LE. 1.0D-15)thisSA%damping=ABS(thisSA%smax-thisSA%smin)/2.0D0
-      TYPEIS(sa_disc_type)
+      TYPE IS(sa_disc_type)
         thisSA%size_states=SIZE(thisSA%state_curr)
         IF(.NOT. ALLOCATED(thisSA%state_neigh))THEN
           ALLOCATE(thisSA%state_neigh(thisSA%size_states))
@@ -221,13 +221,13 @@ CONTAINS
       thisSA%total_steps=thisSA%total_steps+1
       !get a new neighbor and compute energy
       SELECTTYPE(thisSA)
-        TYPEIS(sa_comb_type)
+        TYPE IS(sa_comb_type)
           thisSA%state_neigh=thisSA%get_neigh(thisSA%state_curr)
           e_neigh=thisSA%energy(thisSA%state_neigh)
-        TYPEIS(sa_cont_type)
+        TYPE IS(sa_cont_type)
           thisSA%state_neigh=thisSA%get_neigh(thisSA%state_curr,thisSA%damping,thisSA%smax,thisSA%smin)
           e_neigh=thisSA%energy(thisSA%state_neigh)
-        TYPEIS(sa_disc_type)
+        TYPE IS(sa_disc_type)
           thisSA%state_neigh=thisSA%get_neigh(thisSA%state_curr)
           e_neigh=thisSA%energy(thisSA%state_neigh)
       ENDSELECT
@@ -239,11 +239,11 @@ CONTAINS
         IF(thisSA%prog_bar .AND. MOD(step,NINT(thisSA%max_step/91.D0)) .EQ. 0) &
           WRITE(*,'(A)',ADVANCE='NO')'*'
         SELECTTYPE(thisSA)
-          TYPEIS(sa_comb_type)
+          TYPE IS(sa_comb_type)
             thisSA%state_curr=thisSA%state_neigh
-          TYPEIS(sa_cont_type)
+          TYPE IS(sa_cont_type)
             thisSA%state_curr=thisSA%state_neigh
-          TYPEIS(sa_disc_type)
+          TYPE IS(sa_disc_type)
             thisSA%state_curr=thisSA%state_neigh
         ENDSELECT
         e_curr=e_neigh
@@ -263,11 +263,11 @@ CONTAINS
       IF(e_curr .LT. thisSA%e_best)THEN
         thisSA%e_best=e_curr
         SELECTTYPE(thisSA)
-          TYPEIS(sa_comb_type)
+          TYPE IS(sa_comb_type)
             thisSA%state_best=thisSA%state_neigh
-          TYPEIS(sa_cont_type)
+          TYPE IS(sa_cont_type)
             thisSA%state_best=thisSA%state_neigh
-          TYPEIS(sa_disc_type)
+          TYPE IS(sa_disc_type)
             thisSA%state_best=thisSA%state_neigh
         ENDSELECT
       ENDIF
@@ -276,14 +276,14 @@ CONTAINS
       IF(ABS(t_curr) .LE. thisSA%resvar)THEN
         thisSA%resvar=thisSA%resvar/2.0D0
         SELECTTYPE(thisSA)
-          TYPEIS(sa_comb_type)
+          TYPE IS(sa_comb_type)
             e_curr=thisSA%e_best
             thisSA%state_curr=thisSA%state_best
-          TYPEIS(sa_cont_type)
+          TYPE IS(sa_cont_type)
             e_curr=thisSA%e_best
             thisSA%state_curr=thisSA%state_best
             IF(thisSA%damp_dyn)thisSA%damping=thisSA%damping/2.0D0
-          TYPEIS(sa_disc_type)
+          TYPE IS(sa_disc_type)
             e_curr=thisSA%e_best
             thisSA%state_curr=thisSA%state_best
         ENDSELECT
@@ -294,11 +294,11 @@ CONTAINS
 
     !set to the best state we ended up finding.
     SELECTTYPE(thisSA)
-      TYPEIS(sa_comb_type)
+      TYPE IS(sa_comb_type)
         thisSA%state_curr=thisSA%state_best
-      TYPEIS(sa_cont_type)
+      TYPE IS(sa_cont_type)
         thisSA%state_curr=thisSA%state_best
-      TYPEIS(sa_disc_type)
+      TYPE IS(sa_disc_type)
         thisSA%state_curr=thisSA%state_best
     ENDSELECT
   ENDSUBROUTINE optimize

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,1 @@
+srcs += files('OpenFSAM.f90')


### PR DESCRIPTION
OpenFSAM (the Fortran module itself) is currently only compiled using Makefiles for the specific example use cases defined within (continuous_test, ising, sa_ts_sa and traveling_sales_general). In order to make use of OpenFSAM in external projects, the module must be copied into the project and compiled there - that's fine, well and good, but I've found it helpful to instead install OpenFSAM as a shared object that I can link against.

To that end, I've thrown together some build definitions that should allow for simple, straightforward installation on Windows, MacOS and GNU/Linux using the [Meson Build System](https://mesonbuild.com).

Those build files not only give the option to install OpenFSAM and allow the user to link to it through pkg-config (on GNU/Linux) but they also compile the examples.

I've kept the Makefiles for each example since they work well and arguably make it easy to compile with different flags. Use your build system of choice for the examples I'd say; potayto/potahto. The examples aren't the main attraction anyways.

A brief installation section was also added to the README.